### PR TITLE
Add the port Env to the env list

### DIFF
--- a/.env.list
+++ b/.env.list
@@ -10,6 +10,7 @@ OC_dbType=postgres
 OC_dbUser=clinica
 OC_dbPass=clinica
 OC_dbHost=oc-db
+OC_DB_PORT_5432_TCP_PORT=5432
 OC_db=openclinica
 OC_userAccountNotification=admin
 OC_supportURL=https://my-cdms.de/openclinica


### PR DESCRIPTION
The current version of this Dockerfiles works with the --link command.
This will be depreciated. To get it to work with user networks the port needs to be properly specified.
The run.sh references OC_DB_PORT_5432_TCP_PORT, but the env file fails to set this.